### PR TITLE
Fix margin parsing.

### DIFF
--- a/app/src/main/java/io/github/benoitduffez/cupsprint/printservice/CupsPrinterDiscoverySession.java
+++ b/app/src/main/java/io/github/benoitduffez/cupsprint/printservice/CupsPrinterDiscoverySession.java
@@ -155,29 +155,13 @@ public class CupsPrinterDiscoverySession extends PrinterDiscoverySession {
 					} else if ("print-color-mode-default".equals(attribute.getName())) {
 						colorDefault = true;
 					} else if ("media-left-margin-supported".equals(attribute.getName())) {
-						for (AttributeValue attributeValue : attribute.getAttributeValue()) {
-							if (Integer.parseInt(attributeValue.getValue()) < marginMilsLeft || marginMilsLeft == 0) {
-								marginMilsLeft = (int) (MM_IN_MILS * Integer.parseInt(attributeValue.getValue()));
-							}
-						}
+						marginMilsLeft = determineMarginFromAttribute(attribute);
 					} else if ("media-right-margin-supported".equals(attribute.getName())) {
-						for (AttributeValue attributeValue : attribute.getAttributeValue()) {
-							if (Integer.parseInt(attributeValue.getValue()) < marginMilsRight || marginMilsRight == 0) {
-								marginMilsRight = (int) (MM_IN_MILS * Integer.parseInt(attributeValue.getValue()));
-							}
-						}
+						marginMilsRight = determineMarginFromAttribute(attribute);
 					} else if ("media-top-margin-supported".equals(attribute.getName())) {
-						for (AttributeValue attributeValue : attribute.getAttributeValue()) {
-							if (Integer.parseInt(attributeValue.getValue()) < marginMilsTop || marginMilsTop == 0) {
-								marginMilsTop = (int) (MM_IN_MILS * Integer.parseInt(attributeValue.getValue()));
-							}
-						}
+						marginMilsTop = determineMarginFromAttribute(attribute);
 					} else if ("media-bottom-margin-supported".equals(attribute.getName())) {
-						for (AttributeValue attributeValue : attribute.getAttributeValue()) {
-							if (Integer.parseInt(attributeValue.getValue()) < marginMilsBottom || marginMilsBottom == 0) {
-								marginMilsBottom = (int) (MM_IN_MILS * Integer.parseInt(attributeValue.getValue()));
-							}
-						}
+						marginMilsBottom = determineMarginFromAttribute(attribute);
 					}
 				}
 			}
@@ -186,6 +170,20 @@ public class CupsPrinterDiscoverySession extends PrinterDiscoverySession {
 			return builder.build();
 		}
 		return null;
+	}
+
+	private int determineMarginFromAttribute(Attribute attribute) {
+		List<AttributeValue> values = attribute.getAttributeValue();
+		if (values.isEmpty()) {
+			return 0;
+		}
+
+		int margin = Integer.MAX_VALUE;
+		for (AttributeValue value : attribute.getAttributeValue()) {
+			int valueMargin = (int) (MM_IN_MILS * Integer.parseInt(value.getValue()) / 100);
+			margin = Math.min(margin, valueMargin);
+		}
+		return margin;
 	}
 
 	/**


### PR DESCRIPTION
PWG JPS3 [1] says margins are given in 1/100 of mm instead of mm as
expected by the previous code. This mismatch can cause the margins to be
larger than the page: e.g. for my HP LaserJet 1018, the margins are 4 mm,
thus the previous code calculated margins of 40 cm on all sides, which
is larger than the 210x297 mm A4 page.

Should fix #7.

[1] https://ftp.pwg.org/pub/pwg/candidates/cs-ippjobprinterext3v10-20120727-5100.13.pdf