### PR TITLE
Solution for the error of bad file descriptor in printDocument

### DIFF
--- a/app/src/main/java/io/github/benoitduffez/cupsprint/printservice/CupsService.kt
+++ b/app/src/main/java/io/github/benoitduffez/cupsprint/printservice/CupsService.kt
@@ -24,7 +24,7 @@ import java.net.URL
 import java.util.HashMap
 import javax.net.ssl.SSLException
 import android.os.ParcelFileDescriptor
-
+import java.io.IOException
 
 
 /**
@@ -105,7 +105,7 @@ class CupsService : PrintService() {
     }
 
     override fun onPrintJobQueued(printJob: PrintJob) {
-        startPolling(printJob)
+        printJob.start()
         val jobInfo = printJob.info
         val printerId = jobInfo.printerId
         if (printerId == null) {
@@ -135,12 +135,23 @@ class CupsService : PrintService() {
                     printDocument(jobId, clientURL, printerURL, data)
                     executors.mainThread.execute { onPrintJobSent(printJob) }
                 } catch (e: Exception) {
-                    executors.mainThread.execute { handleJobException(jobId, e) }
+                    executors.mainThread.execute { handleJobException(printJob, e) }
+                } finally {
+                    // Close the file descriptor, after printing
+                    try {
+                        data.close();
+                    } catch (e: IOException) {
+                        Timber.e("Job document data (file descriptor) couldn't close.")
+                    }
                 }
             }
         } catch (e: MalformedURLException) {
+            // ToDO: Make a resource for the error message
+            printJob.fail("Couldn't queue print job: $printJob")
             Timber.e("Couldn't queue print job: $printJob")
         } catch (e: URISyntaxException) {
+            // ToDO: Make a resource for the error message
+            printJob.fail("Couldn't parse URI: $url")
             Timber.e("Couldn't parse URI: $url")
         }
     }
@@ -152,12 +163,22 @@ class CupsService : PrintService() {
      * @param jobId The print job
      * @param e     The exception that occurred
      */
-    private fun handleJobException(jobId: PrintJobId, e: Exception) {
+    private fun handleJobException(printJob: PrintJob , e: Exception) {
         when (e) {
-            is SocketTimeoutException -> Toast.makeText(this, R.string.err_job_socket_timeout, Toast.LENGTH_LONG).show()
-            is NullPrinterException -> Toast.makeText(this, R.string.err_printer_null_when_printing, Toast.LENGTH_LONG).show()
+            is SocketTimeoutException -> {
+                printJob.fail(getString(R.string.err_job_socket_timeout))
+                Toast.makeText(this, R.string.err_job_socket_timeout, Toast.LENGTH_LONG).show()
+            }
+            is NullPrinterException -> {
+                printJob.fail(getString(R.string.err_printer_null_when_printing));
+                Toast.makeText(this, R.string.err_printer_null_when_printing, Toast.LENGTH_LONG).show()
+            }
             else -> {
-                Toast.makeText(this, getString(R.string.err_job_exception, jobId.toString(), e.localizedMessage), Toast.LENGTH_LONG).show()
+                val jobId = printJob.id
+                val errorMsg = getString(R.string.err_job_exception, jobId.toString(), e.localizedMessage)
+
+                printJob.fail(errorMsg)
+                Toast.makeText(this, errorMsg, Toast.LENGTH_LONG).show()
                 if (e is SSLException && e.message?.contains("I/O error during system call, Broken pipe") == true) {
                     // Don't send this crash report: https://github.com/BenoitDuffez/AndroidCupsPrint/issues/70
                     Timber.e("Couldn't query job $jobId")
@@ -299,7 +320,7 @@ class CupsService : PrintService() {
      * @param printJob The print job
      */
     private fun onPrintJobSent(printJob: PrintJob) {
-        printJob.start()
+        startPolling(printJob)
     }
 
     private class NullPrinterException internal constructor() : Exception("Printer is null when trying to print: printer no longer available?")

--- a/app/src/main/java/org/cups4j/PrintJob.kt
+++ b/app/src/main/java/org/cups4j/PrintJob.kt
@@ -64,7 +64,9 @@ class PrintJob internal constructor(builder: Builder) {
         var copies = 1
         var pageRanges: String? = null
         var userName: String? = null
-        lateinit var jobName: String
+        // ToDo: lateinit don't works
+        //lateinit var jobName: String
+        var jobName: String = ""
         var duplex = false
         var attributes: MutableMap<String, String>? = null
 


### PR DESCRIPTION
In case of small memory the garbage collector automatically close the FileDescriptor in printDocument, because "data" don't have a reference any more and the FileDescriptor is only a wrapper for the pipe number. Then we get an error of "Bad file descriptor". With this change we take directly the ParcelFileDescriptor and hold a reference to "data". So the garbage collector don't close the FileDescriptor.

I also use the AutoCloseInputStream of the ParcelFileDescriptor, because we connect then the InputStream with the ParcelFileDescriptor. When the InputStream would be closed, also the ParcelFileDescriptor is closed automatically.