### PR TITLE
 Filter for CUPS-Get-Printers Request

### DIFF
--- a/app/src/main/java/org/cups4j/CupsClient.kt
+++ b/app/src/main/java/org/cups4j/CupsClient.kt
@@ -64,11 +64,11 @@ class CupsClient @JvmOverloads constructor(
 
     // add default printer if available
     @Throws(Exception::class)
-    fun getPrinters(name: String? = null): List<CupsPrinter> {
+    fun getPrinters(firstName: String? = null, limit: Int? = null): List<CupsPrinter> {
         val cupsGetPrintersOperation = CupsGetPrintersOperation(context)
         val printers: List<CupsPrinter>
         try {
-            printers = cupsGetPrintersOperation.getPrinters(url, path, name)
+            printers = cupsGetPrintersOperation.getPrinters(url, path, firstName, limit)
         } finally {
             serverCerts = cupsGetPrintersOperation.serverCerts
             lastResponseCode = cupsGetPrintersOperation.lastResponseCode
@@ -100,7 +100,7 @@ class CupsClient @JvmOverloads constructor(
             name = name.substring(pos + 1)
         }
 
-        val printers = getPrinters(name)
+        val printers = getPrinters(name, 1)
 
         Timber.d("getPrinter: Found ${printers.size} possible CupsPrinters")
         for (p in printers) {

--- a/app/src/main/java/org/cups4j/operations/cups/CupsGetPrintersOperation.kt
+++ b/app/src/main/java/org/cups4j/operations/cups/CupsGetPrintersOperation.kt
@@ -38,16 +38,22 @@ class CupsGetPrintersOperation(context: Context) : IppOperation(context) {
     }
 
     @Throws(Exception::class)
-    fun getPrinters(url: URL, path: String, name: String? = null): List<CupsPrinter> {
+    fun getPrinters(url: URL, path: String, firstName: String? = null, limit: Int? = null): List<CupsPrinter> {
         val printers = ArrayList<CupsPrinter>()
 
         val map = HashMap<String, String>()
         map["requested-attributes"] = "copies-supported page-ranges-supported printer-name printer-info printer-location printer-make-and-model printer-uri-supported"
 
-        // When a name is given, search only for this printer
-        if (name != null) {
-            map["first-printer-name"] = name
-            map["limit"] = "1"
+        // When a firstName is given, the returned list starts with this printer
+        if (firstName != null) {
+            map["first-printer-name"] = firstName
+        }
+
+        // When a limit is given, this is the maximum length of the returned list
+        if (limit != null) {
+            if (limit >= 1) {
+                map["limit"] = limit.toString()
+            }
         }
 
         val result = request(URL(url.toString() + path), map)

--- a/app/src/main/java/org/cups4j/operations/cups/CupsGetPrintersOperation.kt
+++ b/app/src/main/java/org/cups4j/operations/cups/CupsGetPrintersOperation.kt
@@ -38,11 +38,17 @@ class CupsGetPrintersOperation(context: Context) : IppOperation(context) {
     }
 
     @Throws(Exception::class)
-    fun getPrinters(url: URL, path: String): List<CupsPrinter> {
+    fun getPrinters(url: URL, path: String, name: String? = null): List<CupsPrinter> {
         val printers = ArrayList<CupsPrinter>()
 
         val map = HashMap<String, String>()
         map["requested-attributes"] = "copies-supported page-ranges-supported printer-name printer-info printer-location printer-make-and-model printer-uri-supported"
+
+        // When a name is given, search only for this printer
+        if (name != null) {
+            map["first-printer-name"] = name
+            map["limit"] = "1"
+        }
 
         val result = request(URL(url.toString() + path), map)
 


### PR DESCRIPTION
In `CupsClient.getPrinter()` we still request the complete list of printers from the cups server and search for the right printer. But in the "CUPS-Get-Printers Request" we could define a "first-printer-name" and a "limit". With these attributes it is possible to get only the wanted printer and not the whole list of printers. If the list of printers is very long, this request should be much faster.

In `CupsClient.getPrinters(firstName: String? = null, limit: Int? = null)` i only change the parameter and give it to `cupsGetPrintersOperation.getPrinters(url, path, firstName, limit)`. Github still shows much changes, because i must change it from a properties to a function.