### PR TITLE
Added onStopPrinterDiscovery and onStopPrinterStateTracking 

### DIFF
--- a/app/src/main/java/io/github/benoitduffez/cupsprint/detect/MdnsServices.kt
+++ b/app/src/main/java/io/github/benoitduffez/cupsprint/detect/MdnsServices.kt
@@ -21,7 +21,7 @@ private val FOOTER = byteArrayOf(0, 0, 12, 0, 1)
 private const val TIMEOUT = 1000
 
 class MdnsServices {
-    private var error = false
+    @Volatile private var error = false // Threadsafe state of error
 
     /**
      * @return the last exception that occurred while trying to connect to scanned hosts

--- a/app/src/main/java/io/github/benoitduffez/cupsprint/printservice/CupsPrinterDiscoverySession.kt
+++ b/app/src/main/java/io/github/benoitduffez/cupsprint/printservice/CupsPrinterDiscoverySession.kt
@@ -23,6 +23,7 @@ import io.github.benoitduffez.cupsprint.detect.MdnsServices
 import io.github.benoitduffez.cupsprint.detect.PrinterRec
 import org.cups4j.CupsClient
 import org.cups4j.CupsPrinter
+import org.cups4j.operations.IppOperation
 import org.cups4j.operations.ipp.IppGetPrinterAttributesOperation
 import org.koin.android.ext.android.inject
 import timber.log.Timber
@@ -40,6 +41,7 @@ import java.security.cert.CertificateException
 import java.security.cert.X509Certificate
 import java.util.ArrayList
 import java.util.HashMap
+import java.util.concurrent.ConcurrentHashMap
 import javax.net.ssl.SSLException
 import javax.net.ssl.SSLPeerUnverifiedException
 
@@ -51,6 +53,10 @@ internal class CupsPrinterDiscoverySession(private val printService: PrintServic
     private var serverCerts: Array<X509Certificate>? = null // If the server sends a non-trusted cert, it will be stored here
     private var unverifiedHost: String? = null // If the SSL hostname cannot be verified, this will be the hostname
     private val appExecutors: AppExecutors by printService.inject()
+    private var ippPrintersStateTracking = ConcurrentHashMap<PrinterId, IppOperation>(3, 0.9f, 4) // Threadsafe access for 4 threads to ippOperation in PrinterStateTracking
+    @Volatile private var mdnsPrinterDiscovery: MdnsServices? = null // Threadsafe access to mdnsService at PrinterDiscovery
+    @Volatile private var runningPrinterDiscovery: Boolean = false // Threadsafe state of PrinterDiscovery
+
 
     /**
      * Called when the framework wants to find/discover printers
@@ -59,11 +65,17 @@ internal class CupsPrinterDiscoverySession(private val printService: PrintServic
      * @param priorityList The list of printers that the user selected sometime in the past, that need to be checked first
      */
     override fun onStartPrinterDiscovery(priorityList: List<PrinterId>) {
+        // ToDo: Use the priorityList
+
         appExecutors.networkIO.execute {
+            runningPrinterDiscovery = true
             val printers = scanPrinters()
-            appExecutors.mainThread.execute {
-                onPrintersDiscovered(printers)
+            if (runningPrinterDiscovery) {
+                appExecutors.mainThread.execute {
+                    onPrintersDiscovered(printers)
+                }
             }
+            runningPrinterDiscovery = false
         }
     }
 
@@ -141,8 +153,13 @@ internal class CupsPrinterDiscoverySession(private val printService: PrintServic
             propertyMap["requested-attributes"] = TextUtils.join(" ", REQUIRED_ATTRIBUTES)
 
             val op = IppGetPrinterAttributesOperation(printService)
+            ippPrintersStateTracking[printerId] = op
             val builder = PrinterCapabilitiesInfo.Builder(printerId)
             val ippAttributes = op.request(printerURL, propertyMap)
+            if (op.isAborted()){
+                return null
+            }
+            ippPrintersStateTracking.remove(printerId)
             if (ippAttributes == null) {
                 Timber.e("Couldn't get 'requested-attributes' from printer: $url")
                 return null
@@ -318,7 +335,9 @@ internal class CupsPrinterDiscoverySession(private val printService: PrintServic
      */
     private fun scanMDnsPrinters(printers: HashMap<String, String>) {
         val mdns = MdnsServices()
+        mdnsPrinterDiscovery = mdns
         val result = mdns.scan()
+        mdnsPrinterDiscovery = null
         result.printers?.forEach { rec ->
             val mDnsUrl = rec.protocol + "://" + rec.host + ":" + rec.port + "/printers/" + rec.queue
             printers[mDnsUrl] = rec.nickname
@@ -358,7 +377,8 @@ internal class CupsPrinterDiscoverySession(private val printService: PrintServic
     }
 
     override fun onStopPrinterDiscovery() {
-        //TODO
+        runningPrinterDiscovery = false
+        mdnsPrinterDiscovery?.stop()
     }
 
     override fun onValidatePrinters(printerIds: List<PrinterId>) {
@@ -378,9 +398,13 @@ internal class CupsPrinterDiscoverySession(private val printService: PrintServic
 
             try {
                 val printerCapabilitiesInfo = checkPrinter(printerId.localId, printerId)
-                Timber.v("HTTP response code: $responseCode")
-                appExecutors.mainThread.execute {
-                    onPrinterChecked(printerId, printerCapabilitiesInfo)
+                if (ippPrintersStateTracking[printerId]?.isAborted() == true) {
+                    Timber.v("Checking Printer is aborted")
+                } else {
+                    Timber.v("HTTP response code: $responseCode")
+                    appExecutors.mainThread.execute {
+                        onPrinterChecked(printerId, printerCapabilitiesInfo)
+                    }
                 }
             } catch (e: Exception) {
                 appExecutors.mainThread.execute {
@@ -469,7 +493,7 @@ internal class CupsPrinterDiscoverySession(private val printService: PrintServic
     }
 
     override fun onStopPrinterStateTracking(printerId: PrinterId) {
-        // TODO?
+        ippPrintersStateTracking[printerId]?.abort()
     }
 
     override fun onDestroy() {}

--- a/app/src/main/java/org/cups4j/operations/IppOperation.kt
+++ b/app/src/main/java/org/cups4j/operations/IppOperation.kt
@@ -42,6 +42,7 @@ import java.net.HttpURLConnection
 import java.net.URL
 import java.nio.ByteBuffer
 import java.security.cert.X509Certificate
+import java.util.concurrent.atomic.AtomicBoolean
 import javax.net.ssl.HttpsURLConnection
 
 abstract class IppOperation(val context: Context) {
@@ -51,6 +52,9 @@ abstract class IppOperation(val context: Context) {
         private set // store the certificates sent by the server if it's not trusted
     var lastResponseCode: Int = 0
         private set
+    private val aborted: AtomicBoolean = AtomicBoolean(false)
+    @Volatile private var threadRef: Thread? = null
+
 
     /**
      * Gets the IPP header
@@ -118,11 +122,16 @@ abstract class IppOperation(val context: Context) {
      */
     @Throws(Exception::class)
     private fun sendRequest(url: URL, ippBuf: ByteBuffer, documentStream: InputStream? = null): IppResult? {
+        if (isAborted()){ return null }
+
         val ippResult: IppResult
         val connection = url.openConnection() as HttpURLConnection
         lastResponseCode = 0
 
         try {
+            // Set the thread reference for Interruption in abort()
+            threadRef = Thread.currentThread()
+
             connection.requestMethod = "POST"
             connection.readTimeout = 10000
             connection.connectTimeout = 10000
@@ -152,15 +161,20 @@ abstract class IppOperation(val context: Context) {
             // Send the data
             copy(inputStream, connection.outputStream)
 
+            if (isAborted()){ return null }
+
             // Read response
             val result = readInputStream(connection.inputStream)
             lastResponseCode = connection.responseCode
+
+            if (isAborted()){ return null }
 
             // Prepare IPP result
             val ippResponse = IppResponse()
             ippResult = ippResponse.getResponse(ByteBuffer.wrap(result))
             ippResult.httpStatusResponse = connection.responseMessage
         } catch (e: Exception) {
+            if (isAborted()){ return null }
             lastResponseCode = connection.responseCode
             Timber.e("Caught exception while connecting to printer $url: HTTP ${connection.responseCode} ${connection.responseMessage}")
             Timber.e("Exception: ${e.message} - $e")
@@ -173,9 +187,32 @@ abstract class IppOperation(val context: Context) {
                 }
             }
             connection.disconnect()
+
+            // Clear the interrupted status and the thread reference
+            Thread.interrupted()
+            threadRef = null
         }
 
         return ippResult
+    }
+
+    /**
+     * Abort the IppOperation and stops the transfer directly
+     */
+    fun abort() {
+        if (this.aborted.compareAndSet(false, true)) {
+            // Interrupt the thread reference
+            threadRef?.interrupt()
+        }
+    }
+
+    /**
+     * Tests whether this IppOperation has been aborted.
+     *
+     * @return true if this IppOperation has been aborted; false otherwise.
+     */
+    fun isAborted(): Boolean {
+        return this.aborted.get()
     }
 
     /**
@@ -192,7 +229,7 @@ abstract class IppOperation(val context: Context) {
         var nRead: Int
         val data = ByteArray(16384)
 
-        while (true) {
+        while (!this.aborted.get()) {
             nRead = `is`.read(data, 0, data.size)
             if (nRead == -1) {
                 break
@@ -225,7 +262,7 @@ abstract class IppOperation(val context: Context) {
             val bufSize = 0x1000 // 4K
             val buf = ByteArray(bufSize)
             var total: Long = 0
-            while (true) {
+            while (!Thread.interrupted()) {
                 val r = from.read(buf)
                 if (r == -1) {
                     break


### PR DESCRIPTION
I make the IppOperation abortable now, like the original cups4j. With this it is possible to stop the PrinterStateTracking if you change the printer or cancel the printing Dialog. With this the network performance should be better, because there isn't unnecessary traffic. Also stop the PrinterDiscovery now, if you cancel the printing dialog. We shouldn't search for printers if we don't need it any more.